### PR TITLE
Some changes in mutacc/utils/fastq_handler.py

### DIFF
--- a/mutacc/utils/fastq_handler.py
+++ b/mutacc/utils/fastq_handler.py
@@ -47,6 +47,9 @@ def fastq_extract(fastq_files: list, record_ids: set, dir_path = ''):
         out_handles = [stack.enter_context(gzip.open(dir_path.joinpath(file_name + "_mutacc" +
             ".fastq.gz"), 'wt')) \
                 for file_name in file_names]
+        
+        #Making buffers
+        out_buffers = [RecordBuffer(out_handle, buffer_size = 500) for out_handle in out_handles]
 
         #parse fastq and places in list fastqs
         #FastqGeneralIterator parses each record as a tuple with name, seq, and quality
@@ -54,6 +57,7 @@ def fastq_extract(fastq_files: list, record_ids: set, dir_path = ''):
         fastqs = [FastqGeneralIterator(handle) for handle in fastq_handles]
         
         record_count = 0
+        records_found = 0
         #Iterates over parsed fastq files simultaneously
         for records in zip(*fastqs):
             
@@ -63,11 +67,13 @@ def fastq_extract(fastq_files: list, record_ids: set, dir_path = ''):
             #Example: if records[0][0] is 'ST-E00266:38:H2TF5CCXX:8:1101:2563:2170 1:N:0:CGCGCATT',
             # records[0][0].split()[0] is 'ST-E00266:38:H2TF5CCXX:8:1101:2563:2170'
             if records[0][0].split()[0].split("/")[0] in record_ids:
+                
+                records_found += 1
 
                 #Writes current records from each fastq file to corresponding output file
-                for record, out_handle in zip(records, out_handles):
+                for record, out_buffer in zip(records, out_buffers):
 
-                    out_handle.write("@%s\n%s\n+\n%s\n" % (record[0], record[1], record[2]))
+                    out_buffer.add("@%s\n%s\n+\n%s\n" % (record[0], record[1], record[2]))
                 
                 #removes found record name from the record_ids set
                 record_ids.remove(records[0][0].split()[0].split("/")[0]) 
@@ -81,7 +87,10 @@ def fastq_extract(fastq_files: list, record_ids: set, dir_path = ''):
             record_count += 1
             if record_count%1e6 == 0:
                 #TO BE REPLACED WITH PROPER PROGRESS BAR/STATUS OF SOME KIND
-                print("##### {}M READS PROCESSED #####".format(record_count/1e6), end="\r")
+                print("##### {}M READS PROCESSED: {} READS FOUND #####".format(record_count/1e6,
+                    records_found), end="\r")
+        
+        for out_buffer in out_buffers: out_buffer.flush()
 
     #Returns the file paths for the output fastq files, that should only contain the records
     #with its record name in record_ids
@@ -89,5 +98,104 @@ def fastq_extract(fastq_files: list, record_ids: set, dir_path = ''):
 
     return out_paths
 
+#Does the reverse as the above function
+def fastq_exclude(fastq_files: list, record_ids: set, dir_path = ''):
+
+    """
+
+        Given a list of read identifiers, and one or two (for paired end) fastq files, 
+        creates new fastq files excluding the reads specified. 
+
+        Args:
+            
+            fastq_files (list): List of fastq files
+            record_ids (set): Set of read names
+            dir_path (string): path to directory where new fastq files are written to
+        
+        Returns:
+
+            out_paths (list): List of paths to newly created fastq files
+
+    """
+    
+    
+    fastq_files = [parse_path(fastq_file) for fastq_file in fastq_files]
+
+    file_names = [Path(file_name).name.split(".")[0] for file_name in fastq_files]
+
+    dir_path = parse_path(dir_path, file_type = 'dir')
+
+    with ExitStack() as stack:
+        fastq_handles = [stack.enter_context(get_file_handle(fastq_file)) \
+                for fastq_file in fastq_files]
+        
+        out_handles = [stack.enter_context(gzip.open(dir_path.joinpath(file_name + "_mutacc" +
+            ".fastq.gz"), 'wt')) \
+                for file_name in file_names]
+        
+        out_buffers = [RecordBuffer(out_handle, buffer_size = 500) for out_handle in out_handles]
+
+        fastqs = [FastqGeneralIterator(handle) for handle in fastq_handles]
+        
+        record_count = 0
+        for records in zip(*fastqs):
+            #only difference from extract function above; here we want to find records with read
+            #names NOT IN the record_ids            
+            if records[0][0].split()[0].split("/")[0] not in record_ids:
+                
+                for record, out_buffer in zip(records, out_buffers):
+
+                    out_buffer.add("@%s\n%s\n+\n%s\n" % (record[0], record[1], record[2]))
+                
+            record_count += 1
+            if record_count%1e6 == 0:
+                print("##### {}M READS PROCESSED #####".format(record_count/1e6), end="\r")
+        
+        for out_buffer in out_buffers: out_buffer.flush()
+
+        out_paths = [out_handle.name for out_handle in out_handles]
+
+    return out_paths
+
+#To avoid writing to disk too many times (especially when using the fastq_exclude function)
+#This buffer holds the fastq records and writes to disk when it is sufficiently large.
+class RecordBuffer:
+
+    def __init__(self, write_handle, buffer_size = 5000):
+        """
+            Buffer for fastq records
+
+            Args:
+                write_handle(file_handle): file handle opened with 'w' for output file
+                buffer_size(int): size of maximum records to store in memory
+
+        """
+        self.buffer = ""
+        self.record_count = 0
+        self.write_handle = write_handle
+        self.buffer_size = buffer_size
+
+    def add(self, record):
+        """
+            adds record to buffer
+
+            Args:
+                record(string): record to be added to buffer
+        """
+        self.buffer += record
+        self.record_count += 1
+
+        if self.record_count == self.buffer_size:
+
+            self.flush()
+
+    def flush(self):
+        """
+            Flushing buffer to write_handle
+        """
+        self.write_handle.write(self.buffer)
+        self.buffer = ""
+        self.record_count = 0
+        
 
 


### PR DESCRIPTION
Added function fastq_exclude, which does the same as fastq_extract. i.e.
for a list of read names, a new fastq file is written excluding reads in
the list. This, for large fastq files will mean a lot of 'write'
operations to the disk, to avoid this, a class 'RecordBuffer' is
implemented, holding several fast records in memory, and writing to file 
when sufficiently large.