### PR TITLE
Extract reads from bam directly, change in collection schemas

### DIFF
--- a/mutacc/builds/build_case.py
+++ b/mutacc/builds/build_case.py
@@ -77,6 +77,9 @@ class CompleteCase:
             
             bam_file = sample_object["bam_file"] #Get bam file fro sample
             
+            sample_dir = make_dir(
+                out_dir.joinpath(sample_object['sample_id'])
+                )
             #If fastq files are given, the reads will be extracted from these.
             if sample_object.get("fastq_files"):
 
@@ -85,22 +88,30 @@ class CompleteCase:
                 #For each variant, the reads spanning this genomic region in the bam file are found
                 for variant in self.variants_object:
                     
-                    
-                    read_ids = read_ids.union(get_overlaping_reads(start = variant["reads_region"]["start"], 
-                                                                   end = variant["reads_region"]["end"],
-                                                                   chrom = variant["chrom"],
-                                                                   fileName = bam_file))
+                    overlapping = get_overlaping_reads(
+                        start = variant["reads_region"]["start"], 
+                        end = variant["reads_region"]["end"],
+                        chrom = variant["chrom"],
+                        fileName = bam_file
+                    )
+
+                    read_ids = read_ids.union(overlapping)
                 
-                LOG.info("{} reads found for sample {}".format(len(read_ids), sample_object['sample_id']))
+                LOG.info("{} reads found for sample {}".format(
+                    len(read_ids), 
+                    sample_object['sample_id']
+                    )
+                )
 
                 #Given the read_ids, and the fastq files, the reads are extracted from the fastq files    
                 LOG.info("Search in fastq file")
                 
-                sample_dir = make_dir(out_dir.joinpath(sample_object['sample_id']))
 
-                variant_fastq_files = fastq_extract(sample_object["fastq_files"], 
-                                                    read_ids,
-                                                    dir_path = sample_dir) 
+                variant_fastq_files = fastq_extract(
+                    sample_object["fastq_files"], 
+                    read_ids,
+                    dir_path = sample_dir
+                    ) 
                 
                 #Add path to fastq files with the reads containing the variant to the sample object
                 sample_object["variant_fastq_files"] = variant_fastq_files
@@ -109,16 +120,21 @@ class CompleteCase:
             #instead.  
             else:
 
-                sample_dir = make_dir(out_dir.joinpath(sample_object['sample_id']))
                 with BAMContext(bam_file, sample_dir) as bam_handle:
                     
                     for variant in self.variants_object:
 
-                        bam_handle.find_reads_from_region(chrom = variant["chrom"],
-                                                          start = variant["reads_region"]["start"],
-                                                          end = variant["reads_region"]["end"])
+                        bam_handle.find_reads_from_region(
+                                chrom = variant["chrom"],
+                                start = variant["reads_region"]["start"],
+                                end = variant["reads_region"]["end"]
+                                )
                     
-                    LOG.info("{} reads found for sample {}".format(bam_handle.record_number, sample_object['sample_id']))
+                    LOG.info("{} reads found for sample {}".format(
+                        bam_handle.record_number, 
+                        sample_object['sample_id']
+                        )
+                    )
 
                     variant_bam_file = bam_handle.out_file
                     

--- a/mutacc/builds/build_case.py
+++ b/mutacc/builds/build_case.py
@@ -77,6 +77,7 @@ class CompleteCase:
             
             bam_file = sample_object["bam_file"] #Get bam file fro sample
             
+            #If fastq files are given, the reads will be extracted from these.
             if sample_object.get("fastq_files"):
 
                 read_ids = set() #Holds the read_ids from the bam file
@@ -104,9 +105,12 @@ class CompleteCase:
                 #Add path to fastq files with the reads containing the variant to the sample object
                 sample_object["variant_fastq_files"] = variant_fastq_files
             
+            #If the fastq files is not given as input, the reads will be extracted from the bam
+            #instead.  
             else:
 
-                with BAMContext(bam_file) as bam_handle:
+                sample_dir = make_dir(out_dir.joinpath(sample_object['sample_id']))
+                with BAMContext(bam_file, sample_dir) as bam_handle:
                     
                     for variant in self.variants_object:
 
@@ -114,11 +118,9 @@ class CompleteCase:
                                                           start = variant["reads_region"]["start"],
                                                           end = variant["reads_region"]["end"])
                     
-                    LOG.info("{} reads found for sample {}".format(bam_handle.record_number(), sample_object['sample_id']))
-                    
-                    sample_dir = make_dir(out_dir.joinpath(sample_object['sample_id']))
+                    LOG.info("{} reads found for sample {}".format(bam_handle.record_number, sample_object['sample_id']))
 
-                    variant_bam_file = bam_handle.dump_to_file(sample_dir)
+                    variant_bam_file = bam_handle.out_file
                     
                     sample_object["variant_bam_file"] = variant_bam_file
 

--- a/mutacc/builds/build_variant.py
+++ b/mutacc/builds/build_variant.py
@@ -72,8 +72,10 @@ class Variant:
         """
             makes a dictionary of the variant to be loaded into a mongodb
         """
+
+        #Find genotype and sample id for the samples given in the vcf file
         samples = [{ 'sample_id': self.samples[i], 
-                     'genotype': str(self.entry.genotypes[i]) } for i in
+                     'genotype': str(self.entry.genotypes[i][0])+"/"+str(self.entry.genotypes[i][1])} for i in
                    range(len(self.samples))]
         self.variant = {
                 

--- a/mutacc/builds/build_variant.py
+++ b/mutacc/builds/build_variant.py
@@ -75,14 +75,24 @@ class Variant:
 
         #Find genotype and sample id for the samples given in the vcf file
         samples = [{ 'sample_id': self.samples[i], 
-                     'genotype': str(self.entry.genotypes[i][0])+"/"+str(self.entry.genotypes[i][1])} for i in
-                   range(len(self.samples))]
+                     'genotype': '/'.join(
+                        [
+                        str(self.entry.genotypes[i][0]),
+                        str(self.entry.genotypes[i][1])
+                        ]
+                    )
+                } for i in range(len(self.samples))]
+
         self.variant = {
                 
-                "display_name": self.entry.CHROM + "_" +
-                                str(self.entry.POS) + "_" +
-                                self.entry.REF + "_" +
-                                self.entry.ALT[0],
+                "display_name": '_'.join(
+                    [
+                        self.entry.CHROM, 
+                        str(self.entry.POS),
+                        self.entry.REF,
+                        self.entry.ALT[0]
+                    ]  
+                ),
                 "variant_type": self.vtype,
                 "alt": self.entry.ALT,
                 "ref": self.entry.REF,

--- a/mutacc/builds/build_variant.py
+++ b/mutacc/builds/build_variant.py
@@ -7,10 +7,10 @@ from mutacc.parse.path_parse import parse_path
 #attempts to 
 class Variant:
 
-    def __init__(self, vcf_entry):
+    def __init__(self, vcf_entry, samples):
 
         self.entry = vcf_entry
-        
+        self.samples = samples
     def find_region(self, padding):
         """
             Given a vcf entry, this function attempts to return the relevant genomic regions
@@ -72,8 +72,15 @@ class Variant:
         """
             makes a dictionary of the variant to be loaded into a mongodb
         """
+        samples = [{ 'sample_id': self.samples[i], 
+                     'genotype': str(self.entry.genotypes[i]) } for i in
+                   range(len(self.samples))]
         self.variant = {
-
+                
+                "display_name": self.entry.CHROM + "_" +
+                                str(self.entry.POS) + "_" +
+                                self.entry.REF + "_" +
+                                self.entry.ALT[0],
                 "variant_type": self.vtype,
                 "alt": self.entry.ALT,
                 "ref": self.entry.REF,
@@ -81,8 +88,8 @@ class Variant:
                 "start": self.entry.start,
                 "end": self.entry.end,
                 "vcf_entry": str(self.entry),
-                "reads_region": self.region 
-                
+                "reads_region": self.region, 
+                "samples": samples
                 }
 
     @property
@@ -109,9 +116,11 @@ def get_variants(vcf_file):
 
     vcf = VCF(str(vcf_file), 'r')
 
+    samples = vcf.samples
+
     for entry in vcf:
 
-        yield Variant(entry)
+        yield Variant(entry, samples)
 
     vcf.close()
 

--- a/mutacc/cli/importing.py
+++ b/mutacc/cli/importing.py
@@ -33,11 +33,11 @@ def importing(context, case, padding):
         raise MongoWriteError("Case %s already exists" % (case.case_id)) 
     
     #Check if any sample_id already exist in collection 'samples'
-    for sample_id in case.sample_ids:
-
-        if adapter.sample_exists(sample_id):
-            LOG.warning("sample_id not unique")
-            raise MongoWriteError("Sample %s already exists" % (sample_id))
+    #for sample_id in case.sample_ids:
+    #
+    #    if adapter.sample_exists(sample_id):
+    #        LOG.warning("sample_id not unique")
+    #        raise MongoWriteError("Sample %s already exists" % (sample_id))
 
     case.get_variants(padding = padding)
     case.get_samples(context.obj['mutacc_dir'])

--- a/mutacc/cli/importing.py
+++ b/mutacc/cli/importing.py
@@ -32,13 +32,6 @@ def importing(context, case, padding):
         LOG.warning("case_id not unique")        
         raise MongoWriteError("Case %s already exists" % (case.case_id)) 
     
-    #Check if any sample_id already exist in collection 'samples'
-    #for sample_id in case.sample_ids:
-    #
-    #    if adapter.sample_exists(sample_id):
-    #        LOG.warning("sample_id not unique")
-    #        raise MongoWriteError("Sample %s already exists" % (sample_id))
-
     case.get_variants(padding = padding)
     case.get_samples(context.obj['mutacc_dir'])
     case.get_case()

--- a/mutacc/mutaccDB/db_adapter.py
+++ b/mutacc/mutaccDB/db_adapter.py
@@ -33,13 +33,8 @@ class MutaccAdapter(MongoAdapter):
 
             self.db.create_collection("cases", validator = CASE_VALIDATOR)
 
-        #if "samples" not in self.db.collection_names():
-
-        #    self.db.create_collection("samples", validator = SAMPLE_VALIDATOR)
-  
         self.variants_collection = self.db.variants
         self.cases_collection = self.db.cases
-        #self.samples_collection = self.db.samples
 
     def add_variants(self, variants):
         """
@@ -65,17 +60,6 @@ class MutaccAdapter(MongoAdapter):
         """
         self.cases_collection.insert_one(case)
 
-    #def add_samples(self, samples):
-    #    """
-    #        Adds samples to collection 'samples'
-    #
-    #        Args:
-    #            samples(list): list of samples, represented as dictionaries, containing information
-    #            about the samples.
-    #            
-    #    """
-    #    self.samples_collection.insert_many(samples)
-
     def case_exists(self, case_id):
         """
             Check if collection with field 'case_id': case_id exists.
@@ -91,16 +75,3 @@ class MutaccAdapter(MongoAdapter):
 
         return False
 
-    #def sample_exists(self, sample_id):    
-    #    """
-    #        Check if sample with 'sample_id': sample_id exists.
-    #
-    #        Args:
-    #            sample_id(str): name of sample
-    #        Returns:
-    #            exists(bool): True if exists, else False
-    #    """
-    #    if self.samples_collection.find({"sample_id": sample_id}).count() > 0:
-    #        return True
-    #
-    #    return False

--- a/mutacc/mutaccDB/db_adapter.py
+++ b/mutacc/mutaccDB/db_adapter.py
@@ -33,13 +33,13 @@ class MutaccAdapter(MongoAdapter):
 
             self.db.create_collection("cases", validator = CASE_VALIDATOR)
 
-        if "samples" not in self.db.collection_names():
+        #if "samples" not in self.db.collection_names():
 
-            self.db.create_collection("samples", validator = SAMPLE_VALIDATOR)
+        #    self.db.create_collection("samples", validator = SAMPLE_VALIDATOR)
   
         self.variants_collection = self.db.variants
         self.cases_collection = self.db.cases
-        self.samples_collection = self.db.samples
+        #self.samples_collection = self.db.samples
 
     def add_variants(self, variants):
         """
@@ -65,16 +65,16 @@ class MutaccAdapter(MongoAdapter):
         """
         self.cases_collection.insert_one(case)
 
-    def add_samples(self, samples):
-        """
-            Adds samples to collection 'samples'
-
-            Args:
-                samples(list): list of samples, represented as dictionaries, containing information
-                about the samples.
-                
-        """
-        self.samples_collection.insert_many(samples)
+    #def add_samples(self, samples):
+    #    """
+    #        Adds samples to collection 'samples'
+    #
+    #        Args:
+    #            samples(list): list of samples, represented as dictionaries, containing information
+    #            about the samples.
+    #            
+    #    """
+    #    self.samples_collection.insert_many(samples)
 
     def case_exists(self, case_id):
         """
@@ -91,16 +91,16 @@ class MutaccAdapter(MongoAdapter):
 
         return False
 
-    def sample_exists(self, sample_id):    
-        """
-            Check if sample with 'sample_id': sample_id exists.
-
-            Args:
-                sample_id(str): name of sample
-            Returns:
-                exists(bool): True if exists, else False
-        """
-        if self.samples_collection.find({"sample_id": sample_id}).count() > 0:
-            return True
-
-        return False
+    #def sample_exists(self, sample_id):    
+    #    """
+    #        Check if sample with 'sample_id': sample_id exists.
+    #
+    #        Args:
+    #            sample_id(str): name of sample
+    #        Returns:
+    #            exists(bool): True if exists, else False
+    #    """
+    #    if self.samples_collection.find({"sample_id": sample_id}).count() > 0:
+    #        return True
+    #
+    #    return False

--- a/mutacc/mutaccDB/insert.py
+++ b/mutacc/mutaccDB/insert.py
@@ -30,7 +30,7 @@ def insert_entire_case(mutacc_adapter, case):
     for variant in variants:
 
         variant["case"] = case_id
-        variant["samples"] = sample_ids
+        #variant["samples"] = sample_ids
 
     #Insert variants into db and save ObjectIds for the documents as variant_ids
     variant_ids = mutacc_adapter.add_variants(variants)    

--- a/mutacc/mutaccDB/insert.py
+++ b/mutacc/mutaccDB/insert.py
@@ -36,17 +36,17 @@ def insert_entire_case(mutacc_adapter, case):
     variant_ids = mutacc_adapter.add_variants(variants)    
     
     #Add variant_ids and case_id to sample objects
-    for sample in samples:
+    #for sample in samples:
 
-        sample["variants"] = variant_ids
-        sample["case"] = case_id
+    #    sample["variants"] = variant_ids
+    #    sample["case"] = case_id
     
     #Insert sample objects into db
-    mutacc_adapter.add_samples(samples)
+    #mutacc_adapter.add_samples(samples)
 
     #Add variant_ids and sample_ids to case object
     case["variants"] = variant_ids
-    case["samples"] = sample_ids
+    case["samples"] = samples
     
     #Insert case into db
 

--- a/mutacc/mutaccDB/insert.py
+++ b/mutacc/mutaccDB/insert.py
@@ -25,26 +25,16 @@ def insert_entire_case(mutacc_adapter, case):
     samples = case.samples_object
     case = case.case_object
     
-    #add case_id and sample_ids fields for variant objects, pointing to the case, and samples where
+    #add case_id field for variant objects, pointing to the case where
     #the variants come from
     for variant in variants:
 
         variant["case"] = case_id
-        #variant["samples"] = sample_ids
 
     #Insert variants into db and save ObjectIds for the documents as variant_ids
     variant_ids = mutacc_adapter.add_variants(variants)    
     
-    #Add variant_ids and case_id to sample objects
-    #for sample in samples:
-
-    #    sample["variants"] = variant_ids
-    #    sample["case"] = case_id
-    
-    #Insert sample objects into db
-    #mutacc_adapter.add_samples(samples)
-
-    #Add variant_ids and sample_ids to case object
+    #Add variant_ids and sample objects to case object
     case["variants"] = variant_ids
     case["samples"] = samples
     

--- a/mutacc/mutaccDB/schema/case.py
+++ b/mutacc/mutaccDB/schema/case.py
@@ -1,3 +1,7 @@
+from .sample import SAMPLE_VALIDATOR
+
+SAMPLE_OBJECT = SAMPLE_VALIDATOR["$jsonSchema"]
+
 CASE_VALIDATOR = {
         
         "$jsonSchema": {
@@ -18,14 +22,10 @@ CASE_VALIDATOR = {
                     
                     "bsonType": "array",
 
-                    "description": "array of sample_id for all samples in the case",
+                    "description": "array of sample objects in the case",
 
-                    "items": {
+                    "items": SAMPLE_OBJECT
 
-                        "bsonType": "string"
-
-                        }
-                    
                     },
 
                 "variants": {

--- a/mutacc/mutaccDB/schema/sample.py
+++ b/mutacc/mutaccDB/schema/sample.py
@@ -4,36 +4,13 @@ SAMPLE_VALIDATOR = {
             
             "bsonType": "object",
 
-            "required": ["sample_id", "variants", "case", "sex", "analysis_type", "bam_file",
-                "fastq_files", "variant_fastq_files"],
+            "required": ["sample_id", "sex", "analysis_type", "bam_file"],
 
             "properties": {
                 
                 "sample_id": {
                     
                     "bsonType": "string",
-
-                    },
-
-                "variants": {
-                    
-                    "bsonType": "array",
-
-                    "description": "array of of variant _id for variants in the sample",
-
-                    "items": {
-                        
-                        "bsonType": "objectId"
-                        
-                        }
-                    
-                    },
-
-                "case": {
-                    
-                    "bsonType": "string",
-
-                    "description": "case_id for the case that this sample belongs to"
 
                     },
 
@@ -84,7 +61,14 @@ SAMPLE_VALIDATOR = {
 
                             }
 
+                        },
+
+                "variant_bam_file": {
+                        
+                        "bsonType": "string"
+                        
                         }
+
 
                 }
 

--- a/mutacc/mutaccDB/schema/variant.py
+++ b/mutacc/mutaccDB/schema/variant.py
@@ -72,9 +72,27 @@ VARIANT_VALIDATOR = {
 
                     "items": {
                         
-                        "bsonType": "string"
+                        "bsonType": "object",
 
+                        "required": ["sample_id", "genotype"],
+
+                        "properties": {
+                            
+                            "sample_id": {
+                                
+                                "bsonType": "string"
+
+                                },
+                            
+                            "genotype": {
+                                
+                                "bsonType": "string"
+                                
                                 }
+                             
+                            }
+
+                        }
                         
                     },
 

--- a/mutacc/mutaccDB/schema/variant.py
+++ b/mutacc/mutaccDB/schema/variant.py
@@ -4,12 +4,18 @@ VARIANT_VALIDATOR = {
 
             "bsonType": "object",
 
-            "required": ["variant_type", "alt", "ref", "chrom", "start", "end", "vcf_entry", "samples",
+            "required": ["display_name", "variant_type", "alt", "ref", "chrom", "start", "end", "vcf_entry", "samples",
 
                 "case", "reads_region"],
 
             "properties": {
-                
+
+                "display_name": {
+                    
+                    "bsonType": "string"
+
+                    },
+
                 "variant_type": {
                     
                     "bsonType": "string"

--- a/mutacc/parse/yaml_parse.py
+++ b/mutacc/parse/yaml_parse.py
@@ -2,7 +2,7 @@ import yaml
 
 from mutacc.parse.path_parse import parse_path
 
-SAMPLE = ["sample_id", "mother", "father", "bam_file","fastq_files"]
+SAMPLE = ["sample_id", "sex", "mother", "father", "bam_file"]
 class YAMLFieldsError(Exception):
 
     def __init__(self, message):

--- a/mutacc/utils/bam_handler.py
+++ b/mutacc/utils/bam_handler.py
@@ -74,6 +74,8 @@ class BAMContext:
         for read in self.sam.fetch(chrom, start, end):
 
             if read.query_name not in self.reads.keys(): self.reads[read.query_name] = []
+            
+            if len(self.reads[read.query_name]) == self.ends: continue
 
             self.reads[read.query_name].append(read)
         

--- a/mutacc/utils/bam_handler.py
+++ b/mutacc/utils/bam_handler.py
@@ -7,20 +7,16 @@ from mutacc.parse.path_parse import parse_path
 
 def get_overlaping_reads(fileName, chrom, start, end):
     """
-
         Extracts all read names from a bam file, overlapping the specified region.
 
         Args:
-
             fileName (string): name of bam file
             chrom (string): name of chromosome
             start (int): start of region
             end (int): end of region
 
         Returns:
-
             reads (set): set of read names. 
-        
     """
     fileName = parse_path(fileName)
 
@@ -36,12 +32,11 @@ def get_overlaping_reads(fileName, chrom, start, end):
 
     return set(ids)
 
-    
 class BAMContext:
     """
         Context manager to deal with bam files
     """
-    def __init__(self, bam_file, ends:int = 2):
+    def __init__(self, bam_file, out_dir = None, ends:int = 2):
         """
             Args:
                 bam_file(str): path to bam file 
@@ -49,9 +44,14 @@ class BAMContext:
         """
         bam_file = parse_path(bam_file)
         self.file_name = bam_file.name
-        self.sam = pysam.AlignmentFile(bam_file, 'rb')
-        self.reads = {}
-        self.ends = ends
+        self.sam = pysam.AlignmentFile(bam_file, 'rb') #Make AlignmentFile object
+        self.reads = {} #Dictionary to store read pairs under their query_name as key
+        self.ends = ends 
+        self.found_reads = set() #Set of query names where both mates are found
+        if out_dir: #If out_dir is given, open a file to write found records
+            self.out_dir = parse_path(out_dir, file_type = "dir")
+            self.out_name = out_dir.joinpath("mutacc_" + self.file_name)
+            self.out_bam = pysam.AlignmentFile(self.out_name, 'wb', template = self.sam)
 
     def __enter__(self):
 
@@ -60,64 +60,78 @@ class BAMContext:
     def __exit__(self, exc_type, exc_val, exc_tb):
 
         self.sam.close()
+        
+        #If out_dir is given, also close the out_bam file created in __init__
+        if self.out_dir: self.out_bam.close()
 
     def find_reads_from_region(self, chrom, start, end):
         """
-            Given a region defined by chrom, start, end, find all records overlapping with this
-            region
+            Given a region defined by chrom, start, end, find all reads, and mates to those reads 
+            overlapping with this region.
 
             Args:
                 chrom(str): chromosome/contig name
                 start(int): start position
                 end(int): end position
         """
+        #Fetch iterator for reads in given region
         for read in self.sam.fetch(chrom, start, end):
+            #If name of read not among the keys in reads dict AND if both mates have not been found
+            #allready make list to hold mates
+            if read.query_name not in self.reads.keys() and read.query_name not in self.found_reads: 
+                
+                self.reads[read.query_name] = []
+            #If both mates are not found allready, append read to mate list in reads
+            #and write to bam_out. Remove mates from reads dictionary, and add name to found_reads
+            if read.query_name not in self.found_reads:       
 
-            if read.query_name not in self.reads.keys(): self.reads[read.query_name] = []
-            
-            if len(self.reads[read.query_name]) == self.ends: continue
+                self.reads[read.query_name].append(read)
 
-            self.reads[read.query_name].append(read)
+                if len(self.reads[read.query_name]) == self.ends: 
+
+                    self.found_reads = self.found_reads.union({read.query_name})
+                    
+                    #Write to file only if a out_dir is given in __init__
+                    if self.out_dir:
+                        for mate in self.reads[read.query_name]: self.out_bam.write(mate)
+
+                    self.reads.pop(read.query_name)
+
         
-        unmatched = []
-        for key in self.reads.keys():
+        #Find the mates of the reads not found in the same region
+        keys = list(self.reads.keys())
+        for key in keys:
             
-            if len(self.reads[key]) < self.ends:
+            try:
+                self.reads[key].append(self.sam.mate(self.reads[key][0]))
 
-                try:
-                    self.reads[key].append(self.sam.mate(self.reads[key][0]))
+                if self.out_dir: 
+                    for mate in self.reads[key]: self.out_bam.write(mate)
+                self.reads.pop(key)
+                self.found_reads = self.found_reads.union({key})
 
-                except ValueError:
-                    unmatched.append(self.reads[key][0].query_name)
-                    print("Mate not found for read {}".format(self.reads[key][0].query_name))
+            #AlignmentSegment.mate raises ValueError if mate can not be found
+            #If mate is not found, the single read is not added to the out_bam file
+            #(Unless ends argument in __init__ is not set to 1)
+            except ValueError:
+                print("Mate not found for read {}".format(key),
+                        self.reads[key][0].next_reference_id)
         
-        for read in unmatched: self.reads.pop(read)
-
+        
+    @property
     def record_number(self):
 
-        return len(self.reads.keys())
+        return len(self.found_reads)
 
-    def dump_to_file(self, out_dir):
-        """
-            Dumps records in self.reads to a bam file
+    @property
+    def out_file(self):
 
-            Args:
-                out_dir(str): path to directory
-        """
-        out_dir = parse_path(out_dir, file_type = "dir")
-        out_name = out_dir.joinpath("mutacc_" + self.file_name)
-        out_bam = pysam.AlignmentFile(out_name, 'wb', template = self.sam)
-
-        for key in self.reads.keys():
-            if len(self.reads[key]) == self.ends:
-                for read in self.reads[key]: out_bam.write(read)
-       
-        
-        out_bam.close()
-        return str(out_name)
+        return str(self.out_name)
 
     #This method may be implemented using picard FilterSamReads or another faster command line
-    #option later, rather than using pysam. 
+    #option later, rather than using pysam. Currently this iterates through all records in a bam
+    #file and writes the records with names not given in self.found_reads to a new bam. This is
+    #however not much more efficient than to search for reads in fastq files.
     def dump_to_exclude_file(self, out_dir):
         """
             Writes bam file, excluding the reads in self.reads
@@ -125,7 +139,6 @@ class BAMContext:
             Args:
                 out_dir(str): path to directory
         """
-        names = set(self.reads.keys())
 
         out_dir = parse_path(out_dir, file_type = "dir")
         out_name = out_dir.joinpath("mutacc_" + self.file_name)
@@ -136,7 +149,7 @@ class BAMContext:
             if count%1e6 == 0:
                 print("##### {}M READS PROCESSED #####".format(count/1e6), end = "\r")
 
-            if read.query_name not in names:
+            if read.query_name not in self.found_reads:
 
                 out_bam.write(read)
 

--- a/mutacc/utils/bam_handler.py
+++ b/mutacc/utils/bam_handler.py
@@ -35,4 +35,108 @@ def get_overlaping_reads(fileName, chrom, start, end):
     sam_file.close()
 
     return set(ids)
-     
+
+    
+class BAMContext:
+    """
+        Context manager to deal with bam files
+    """
+    def __init__(self, bam_file, ends:int = 2):
+        """
+            Args:
+                bam_file(str): path to bam file 
+                ends(int): 2 if paired end reads, 1 if not
+        """
+        bam_file = parse_path(bam_file)
+        self.file_name = bam_file.name
+        self.sam = pysam.AlignmentFile(bam_file, 'rb')
+        self.reads = {}
+        self.ends = ends
+
+    def __enter__(self):
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+
+        self.sam.close()
+
+    def find_reads_from_region(self, chrom, start, end):
+        """
+            Given a region defined by chrom, start, end, find all records overlapping with this
+            region
+
+            Args:
+                chrom(str): chromosome/contig name
+                start(int): start position
+                end(int): end position
+        """
+        for read in self.sam.fetch(chrom, start, end):
+
+            if read.query_name not in self.reads.keys(): self.reads[read.query_name] = []
+
+            self.reads[read.query_name].append(read)
+        
+        unmatched = []
+        for key in self.reads.keys():
+            
+            if len(self.reads[key]) < self.ends:
+
+                try:
+                    self.reads[key].append(self.sam.mate(self.reads[key][0]))
+
+                except ValueError:
+                    unmatched.append(self.reads[key][0].query_name)
+                    print("Mate not found for read {}".format(self.reads[key][0].query_name))
+        
+        for read in unmatched: self.reads.pop(read)
+
+    def record_number(self):
+
+        return len(self.reads.keys())
+
+    def dump_to_file(self, out_dir):
+        """
+            Dumps records in self.reads to a bam file
+
+            Args:
+                out_dir(str): path to directory
+        """
+        out_dir = parse_path(out_dir, file_type = "dir")
+        out_name = out_dir.joinpath("mutacc_" + self.file_name)
+        out_bam = pysam.AlignmentFile(out_name, 'wb', template = self.sam)
+
+        for key in self.reads.keys():
+            if len(self.reads[key]) == self.ends:
+                for read in self.reads[key]: out_bam.write(read)
+       
+        
+        out_bam.close()
+        return str(out_name)
+
+    #This method may be implemented using picard FilterSamReads or another faster command line
+    #option later, rather than using pysam. 
+    def dump_to_exclude_file(self, out_dir):
+        """
+            Writes bam file, excluding the reads in self.reads
+
+            Args:
+                out_dir(str): path to directory
+        """
+        names = set(self.reads.keys())
+
+        out_dir = parse_path(out_dir, file_type = "dir")
+        out_name = out_dir.joinpath("mutacc_" + self.file_name)
+        out_bam = pysam.AlignmentFile(out_name, 'wb', template = self.sam)
+
+        for count, read in enumerate(self.sam):
+            
+            if count%1e6 == 0:
+                print("##### {}M READS PROCESSED #####".format(count/1e6), end = "\r")
+
+            if read.query_name not in names:
+
+                out_bam.write(read)
+
+        out_names.close()                
+

--- a/mutacc/utils/bam_handler.py
+++ b/mutacc/utils/bam_handler.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import logging
 
 import pysam
 
 from mutacc.parse.path_parse import parse_path
+
+LOG = logging.getLogger(__name__)
 
 def get_overlaping_reads(fileName, chrom, start, end):
     """
@@ -114,8 +117,7 @@ class BAMContext:
             #If mate is not found, the single read is not added to the out_bam file
             #(Unless ends argument in __init__ is not set to 1)
             except ValueError:
-                print("Mate not found for read {}".format(key),
-                        self.reads[key][0].next_reference_id)
+                LOG.warning("Mate not found for read {}".format(key))
         
         
     @property
@@ -147,7 +149,7 @@ class BAMContext:
         for count, read in enumerate(self.sam):
             
             if count%1e6 == 0:
-                print("##### {}M READS PROCESSED #####".format(count/1e6), end = "\r")
+                LOG.info("##### {}M READS PROCESSED #####\r".format(count/1e6))
 
             if read.query_name not in self.found_reads:
 

--- a/mutacc/utils/fastq_handler.py
+++ b/mutacc/utils/fastq_handler.py
@@ -1,10 +1,13 @@
 import gzip
+import logging
 from pathlib import Path
 from contextlib import ExitStack
 
 from Bio.SeqIO.QualityIO import FastqGeneralIterator
 
 from mutacc.parse.path_parse import parse_path, get_file_handle
+
+LOG = logging.getLogger(__name__)
 
 def fastq_extract(fastq_files: list, record_ids: set, dir_path = ''):
 
@@ -85,8 +88,10 @@ def fastq_extract(fastq_files: list, record_ids: set, dir_path = ''):
             
             if count%1e6 == 0:
                 #TO BE REPLACED WITH PROPER PROGRESS BAR/STATUS OF SOME KIND
-                print("##### {}M READS PROCESSED: {} READS FOUND #####".format(count/1e6,
-                    records_found), end="\r")
+                LOG.info("##### {}M READS PROCESSED: {} READS FOUND #####\r".format(
+                    count/1e6,
+                    records_found)
+                    )
         
         #for out_buffer in out_buffers: out_buffer.flush()
 


### PR DESCRIPTION
If no fastq files are given in input, the reads are extracted directly from the bam file.
The db schemas are changed. Now there are only two collections; variants, and cases. the case documents include the variant information. the variant documents now gets a 'display_name', and genotypes for all samples in the input vcd file.

Most interesting new code added in this pull request is the BAMContext class in mutacc/utils/bam_handler.